### PR TITLE
Fixed variable name and changed argument name

### DIFF
--- a/controllers/prompt_handler.py
+++ b/controllers/prompt_handler.py
@@ -18,14 +18,14 @@ session = Session.builder.configs(connection_parameters).create()
 chosen_model = "snowflake-arctic"
 
 summarize_request_str = "Summarize this text in one or two sentences:"
-default_request = summarize_prompt_str
+default_request = summarize_request_str
 
-def get_cortex_response(summarize_text, request = default_request):
-    if not summarize_text or not isinstance(summarize_text, str):
+def get_cortex_response(user_input, request = default_request):
+    if not user_input or not isinstance(user_input, str):
         raise ValueError("Prompt Handler did not receive a valid text for summarization.")
     
-    summarize_text = summarize_text.replace("'", "\\'")
-    prompt = f"{request} {summarize_text}"
+    user_input_trimmed = user_input.replace("'", "\\'")
+    prompt = f"{request} {user_input_trimmed}"
     cortex_prompt = f"'[INST]{prompt}[INST]'"
     cortex_response = session.sql(f"select snowflake.cortex.complete('{chosen_model}', {cortex_prompt}) as response").to_pandas().iloc[0]['RESPONSE']
     return cortex_response


### PR DESCRIPTION
App was breaking when running due to incorrect variable name.
- Fixed variable name
- Changed argument name to `user_input` from `summarize_text`